### PR TITLE
adsAsynPortDriver.cpp: Remove invalid adsUnlock()

### DIFF
--- a/adsApp/src/adsAsynPortDriver.cpp
+++ b/adsApp/src/adsAsynPortDriver.cpp
@@ -276,7 +276,6 @@ adsAsynPortDriver::adsAsynPortDriver(const char *portName,
   routeAdded_=0;
   notConnectedCounter_ = 0;
   oneAmsConnectionOKold_=0;
-  adsUnlock();
 
   //Octet interface
   octetAsciiBuffer_.bufferSize = ADS_CMD_BUFFER_SIZE;


### PR DESCRIPTION
Remove an invalid adsUnlock() in
adsAsynPortDriver::adsAsynPortDriver()
The corresponding adsLock() had never been called.

Thanks to Ivo Hanak for notising this.