### PR TITLE
add explicitely dependency of the adsExApp

### DIFF
--- a/Makefile.epics
+++ b/Makefile.epics
@@ -10,6 +10,7 @@ endef
 $(foreach dir, $(filter-out configure,$(DIRS)),$(eval $(call DIR_template,$(dir))))
 
 iocBoot_DEPEND_DIRS += $(filter %App,$(DIRS))
+adsExApp_DEPEND_DIRS += adsApp
 
 include $(TOP)/configure/RULES_TOP
 


### PR DESCRIPTION
WIth EPNIX project we compile App simultaneously, so we need to declare explicitely the dependency of the App.

Transparent for a classical compilation.

Already merged in the secret repo of ESS ;)