### PR TITLE
adsAsynPortDriver.cpp: Improve logging when adsReadStateLock fails

### DIFF
--- a/adsApp/src/adsAsynPortDriver.cpp
+++ b/adsApp/src/adsAsynPortDriver.cpp
@@ -403,14 +403,15 @@ adsAsynPortDriver::adsAsynPortDriver(const char *portName,
       uint16_t adsState = 0;
       if (adsReadStateLock(amsport,&adsState,true,&error) != asynSuccess) {
           asynPrint(pasynUserSelf, ASYN_TRACE_ERROR,
-                    "%s:%s: adsReadStateLock failed for port %s.\n",
-                    driverName, functionName, portName);
+                    "%s:%s: adsReadStateLock failed for port '%s' error=0x%lx\n",
+                    driverName, functionName, portName, error);
           disconnect(pasynUserSelf);
+          epicsThreadSleep(5.0);
           continue;
       }
       if (adsState == ADSSTATE_RUN) {
           asynPrint(pasynUserSelf, ASYN_TRACE_ERROR,
-                    "%s:%s: connection established for port %s.\n",
+                    "%s:%s: connection established for port '%s'\n",
                     driverName, functionName, portName);
           return;
       }


### PR DESCRIPTION
There was not really much information when adsReadStateLock() failed. One case was that the crate was run with a test-license, which had expired. Improve this a little bit by printing the error code.

Keep the loop to disconnect, reconnect and try again, to be able to recover some day.
Make it less spammy by adding a sleep(10 seconds).