### PR TITLE
Update BeckhoffADS to v22

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,11 +22,13 @@ adsApp/src/LicenseAccess.cpp
 adsApp/src/Log.cpp
 adsApp/src/NotificationDispatcher.cpp
 adsApp/src/O.*
+adsApp/src/ParameterList.cpp
 adsApp/src/RTimeAccess.cpp
 adsApp/src/RegistryAccess.cpp
 adsApp/src/RouterAccess.cpp
 adsApp/src/Sockets.cpp
 adsApp/src/SymbolAccess.cpp
+adsApp/src/example.cpp
 adsExApp/Db/O.*
 adsExApp/src/O.*
 bin/

--- a/Makefile
+++ b/Makefile
@@ -9,34 +9,27 @@
 #
 # Makefile when running gnu make
 
+# Stolen from how the Beckhoff ninja builds the lib
+# With some tweaking afterwards (replace _ with /)
 ADS_FROM_BECKHOFF_SOURCES = \
-BeckhoffADS/example/example.cpp \
-BeckhoffADS/AdsLib/Log.cpp \
-BeckhoffADS/AdsLib/Frame.cpp \
-BeckhoffADS/AdsLib/standalone/AmsRouter.cpp \
-BeckhoffADS/AdsLib/standalone/AdsLib.cpp \
-BeckhoffADS/AdsLib/standalone/NotificationDispatcher.cpp \
-BeckhoffADS/AdsLib/standalone/AmsPort.cpp \
-BeckhoffADS/AdsLib/standalone/AmsConnection.cpp \
-BeckhoffADS/AdsLib/standalone/AmsNetId.cpp \
+BeckhoffADS/AdsLib/AdsDef.cpp \
 BeckhoffADS/AdsLib/AdsFile.cpp \
-BeckhoffADS/AdsLib/TwinCAT/AdsLib.cpp \
-BeckhoffADS/AdsLib/AdsLib.cpp \
+BeckhoffADS/AdsLib/AdsDevice.cpp \
+BeckhoffADS/AdsLib/Frame.cpp \
+BeckhoffADS/AdsLib/Log.cpp \
 BeckhoffADS/AdsLib/LicenseAccess.cpp \
 BeckhoffADS/AdsLib/RTimeAccess.cpp \
+BeckhoffADS/AdsLib/RouterAccess.cpp \
 BeckhoffADS/AdsLib/Sockets.cpp \
-BeckhoffADS/AdsLib/AdsDef.cpp \
+BeckhoffADS/AdsLib/bhf/ParameterList.cpp \
 BeckhoffADS/AdsLib/RegistryAccess.cpp \
 BeckhoffADS/AdsLib/SymbolAccess.cpp \
-BeckhoffADS/AdsLib/bhf/ParameterList.cpp \
-BeckhoffADS/AdsLib/AdsDevice.cpp \
-BeckhoffADS/AdsLib/RouterAccess.cpp \
-
-# Do not include the main programs:
-#BeckhoffADS/AdsLibTest/main.cpp \
-#BeckhoffADS/AdsLibOOITest/main.cpp \
-#BeckhoffADS/AdsTool/main.cpp \
-#BeckhoffADS/AdsLibTestRef/main.cpp \
+BeckhoffADS/AdsLib/standalone/AmsNetId.cpp \
+BeckhoffADS/AdsLib/standalone/AdsLib.cpp \
+BeckhoffADS/AdsLib/standalone/AmsPort.cpp \
+BeckhoffADS/AdsLib/standalone/AmsConnection.cpp \
+BeckhoffADS/AdsLib/standalone/AmsRouter.cpp \
+BeckhoffADS/AdsLib/standalone/NotificationDispatcher.cpp \
 
 
 # download ADS if needed

--- a/Makefile
+++ b/Makefile
@@ -10,16 +10,33 @@
 # Makefile when running gnu make
 
 ADS_FROM_BECKHOFF_SOURCES = \
-  BeckhoffADS/AdsLib/AdsDef.cpp \
-  BeckhoffADS/AdsLib/AdsLib.cpp \
-  BeckhoffADS/AdsLib/AmsConnection.cpp \
-  BeckhoffADS/AdsLib/AmsPort.cpp \
-  BeckhoffADS/AdsLib/AmsRouter.cpp \
-  BeckhoffADS/AdsLib/Log.cpp \
-  BeckhoffADS/AdsLib/NotificationDispatcher.cpp \
-  BeckhoffADS/AdsLib/Sockets.cpp \
-  BeckhoffADS/AdsLib/Frame.cpp \
+BeckhoffADS/example/example.cpp \
+BeckhoffADS/AdsLib/Log.cpp \
+BeckhoffADS/AdsLib/Frame.cpp \
+BeckhoffADS/AdsLib/standalone/AmsRouter.cpp \
+BeckhoffADS/AdsLib/standalone/AdsLib.cpp \
+BeckhoffADS/AdsLib/standalone/NotificationDispatcher.cpp \
+BeckhoffADS/AdsLib/standalone/AmsPort.cpp \
+BeckhoffADS/AdsLib/standalone/AmsConnection.cpp \
+BeckhoffADS/AdsLib/standalone/AmsNetId.cpp \
+BeckhoffADS/AdsLib/AdsFile.cpp \
+BeckhoffADS/AdsLib/TwinCAT/AdsLib.cpp \
+BeckhoffADS/AdsLib/AdsLib.cpp \
+BeckhoffADS/AdsLib/LicenseAccess.cpp \
+BeckhoffADS/AdsLib/RTimeAccess.cpp \
+BeckhoffADS/AdsLib/Sockets.cpp \
+BeckhoffADS/AdsLib/AdsDef.cpp \
+BeckhoffADS/AdsLib/RegistryAccess.cpp \
+BeckhoffADS/AdsLib/SymbolAccess.cpp \
+BeckhoffADS/AdsLib/bhf/ParameterList.cpp \
+BeckhoffADS/AdsLib/AdsDevice.cpp \
+BeckhoffADS/AdsLib/RouterAccess.cpp \
 
+# Do not include the main programs:
+#BeckhoffADS/AdsLibTest/main.cpp \
+#BeckhoffADS/AdsLibOOITest/main.cpp \
+#BeckhoffADS/AdsTool/main.cpp \
+#BeckhoffADS/AdsLibTestRef/main.cpp \
 
 
 # download ADS if needed

--- a/adsApp/src/Makefile
+++ b/adsApp/src/Makefile
@@ -23,7 +23,7 @@ USR_LDFLAGS  += -lpthread
 #=============================
 # Build the IOC application
 
-#LIBRARY_IOC = ads
+LIBRARY_IOC = ads
 
 DBD += ads.dbd
 

--- a/adsApp/src/Makefile
+++ b/adsApp/src/Makefile
@@ -15,13 +15,15 @@ include $(TOP)/configure/CONFIG
 #=============================
 
 USR_CXXFLAGS += -std=c++11
+USR_CXXFLAGS += -DCONFIG_DEFAULT_LOGLEVEL=1
 USR_CPPFLAGS += -I ../../../BeckhoffADS/AdsLib/
+USR_CPPFLAGS += -I ../../../BeckhoffADS/AdsLib/bhf/
 USR_LDFLAGS  += -lpthread
 
 #=============================
 # Build the IOC application
 
-LIBRARY_IOC = ads
+#LIBRARY_IOC = ads
 
 DBD += ads.dbd
 


### PR DESCRIPTION
Update the BeckhoffADS submodule to v22, the latest one released. Add the new files to Makefile, this is still hackish: Running make will, when everything works, copy/softlink all needed cpp files into the adsApp/src directory and include them in the build.
With other words: this Makefile does not create an adslib, as before.

Because: The meson-ish build system under BeckhoffADS does not support MacOs any more, for no good reasons ?

Changes to be committed:
    modified:   .gitignore
    modified:   BeckhoffADS
    modified:   Makefile
    modified:   adsApp/src/Makefile