### PR TITLE
Update BeckhoffADS to v10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,11 +22,13 @@ adsApp/src/LicenseAccess.cpp
 adsApp/src/Log.cpp
 adsApp/src/NotificationDispatcher.cpp
 adsApp/src/O.*
+adsApp/src/ParameterList.cpp
 adsApp/src/RTimeAccess.cpp
 adsApp/src/RegistryAccess.cpp
 adsApp/src/RouterAccess.cpp
 adsApp/src/Sockets.cpp
 adsApp/src/SymbolAccess.cpp
+adsApp/src/example.cpp
 adsExApp/Db/O.*
 adsExApp/src/O.*
 bin/

--- a/Makefile
+++ b/Makefile
@@ -9,17 +9,24 @@
 #
 # Makefile when running gnu make
 
+# Stolen from how the Beckhoff ninja builds the lib
+# With some tweaking afterwards (replace _ with /)
 ADS_FROM_BECKHOFF_SOURCES = \
-  BeckhoffADS/AdsLib/AdsDef.cpp \
-  BeckhoffADS/AdsLib/AdsLib.cpp \
-  BeckhoffADS/AdsLib/AmsConnection.cpp \
-  BeckhoffADS/AdsLib/AmsPort.cpp \
-  BeckhoffADS/AdsLib/AmsRouter.cpp \
-  BeckhoffADS/AdsLib/Log.cpp \
-  BeckhoffADS/AdsLib/NotificationDispatcher.cpp \
-  BeckhoffADS/AdsLib/Sockets.cpp \
-  BeckhoffADS/AdsLib/Frame.cpp \
-
+BeckhoffADS/AdsLib/AdsDef.cpp \
+BeckhoffADS/AdsLib/AdsFile.cpp \
+BeckhoffADS/AdsLib/AdsDevice.cpp \
+BeckhoffADS/AdsLib/Frame.cpp \
+BeckhoffADS/AdsLib/Log.cpp \
+BeckhoffADS/AdsLib/LicenseAccess.cpp \
+BeckhoffADS/AdsLib/RTimeAccess.cpp \
+BeckhoffADS/AdsLib/RouterAccess.cpp \
+BeckhoffADS/AdsLib/Sockets.cpp \
+BeckhoffADS/AdsLib/standalone/AmsNetId.cpp \
+BeckhoffADS/AdsLib/standalone/AdsLib.cpp \
+BeckhoffADS/AdsLib/standalone/AmsPort.cpp \
+BeckhoffADS/AdsLib/standalone/AmsConnection.cpp \
+BeckhoffADS/AdsLib/standalone/AmsRouter.cpp \
+BeckhoffADS/AdsLib/standalone/NotificationDispatcher.cpp \
 
 
 # download ADS if needed


### PR DESCRIPTION
Update BeckhoffADS to version v10
Note: This is the version being used under e3 at ESS

Adapt the Makefile to be able to compile under
"classic epics, non e3 " environments

Due to a mistake in developping the update to v22 this commit has smuggled in a change in .gitignore for the next commit.

Changes to be committed:
    modified:   .gitignore
    modified:   BeckhoffADS
    modified:   Makefile