### PR TITLE
update README: add examples and some details

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ db/
 dbd/
 iocBoot/
 lib/
+.vscode/

--- a/README.md
+++ b/README.md
@@ -1,48 +1,108 @@
-# EPICS Module to communicate with TwinCAT controllers over ADS protocol
+# EPICS TwinCAT-ADS
 
-Originally developed for use with ESS EPICS Environment, but can also be compiled
-for normal EPICS base.
+EPICS Module to communicate with TwinCAT controllers over ADS protocol.
 
-```
+## Install
+
+1. Clone recursively:
+
+```bash
 $ git clone --recursive https://github.com/epics-modules/twincat-ads
 ```
 
-Start an e3 ioc with:
+2. Create a configure/RELEASE.local file with:
+
+```ini
+EPICS_BASE=<path-to-your-base>
+ASYN=<path-to-asyn>
 ```
-$ iocsh adsOnlyIO.cmd
-$ iocsh adsMotorRecord.cmd
-$ iocsh.bash adsMotorRecordOnly.cmd
+
+3. Build and install:
+
+```bash
+make
+make install
 ```
+
+> Note: This module depends on
+> [Beckhoff ADS library](https://github.com/Beckhoff/ADS), which is submoduled
+> here and built from source.
 
 ## Prepare communication between IOC and TwinCAT Controller
-To enable communication between the IOC and TwinCAT Controller, an ADS route needs to be setup. This can be done in at least three different ways:
 
-1. Login to the PLC remotely. Click on the TwinCAT runtime icon (in the field by the Windows clock) -> Router -> Edit Routes. Add the route through the popup window.
+To enable communication between the IOC and TwinCAT Controller, an ADS route
+needs to be setup. This can be done in at least three different ways:
 
-2. Login to the PLC remotely. Edit the C:\TwinCAT\3.1\Target\StaticRoutes.xml manually.
-	```
-	<Route>
-		<Name>epics</Name>
-		<Address>192.168.114.129</Address>
-		<NetId>192.168.114.129.1.1</NetId>
-		<Type>TCP_IP</Type>
-		<Flags>32</Flags>
-	</Route>
-	```
-	*Note 1: Update with the correct IP address and AMSNETID.*
+1. Login to the PLC remotely. Click on the TwinCAT runtime icon (in the field by
+   the Windows clock) -> Router -> Edit Routes. Add the route through the popup
+   window.
 
-	*Note 2: for TwincCAT 4024.0, this is the required method (see https://github.com/Beckhoff/ADS/issues/98).*
+2. Login to the PLC remotely. Edit the C:\TwinCAT\3.1\Target\StaticRoutes.xml
+   manually.
 
-3. Use TwinCAT XAE. Click Solution -> SYSTEM -> Routes and add the route through the popup window.
+   ```
+   <Route>
+   	<Name>epics</Name>
+   	<Address>192.168.114.129</Address>
+   	<NetId>192.168.114.129.1.1</NetId>
+   	<Type>TCP_IP</Type>
+   	<Flags>32</Flags>
+   </Route>
+   ```
 
+   _Note 1: Update with the correct IP address and AMSNETID._
 
+   _Note 2: for TwincCAT 4024.0, this is the required method (see
+   https://github.com/Beckhoff/ADS/issues/98)._
 
+3. Use TwinCAT XAE. Click Solution -> SYSTEM -> Routes and add the route through
+   the popup window.
+
+## Usage
+
+This module allows access to ADS symbols through the following syntax:
+
+```
+@asyn(<PORT>,<ADDR>,<TIMEOUT>)<OPTIONS>/<PLC_SYMBOL>[? | =]
+```
+
+Where:
+
+- `<PORT>,<ADDR> and <TIMEOUT>`: Standard asyn parameters, see
+  [asyn docs](https://epics-modules.github.io/asyn/asynRecord.html#);
+- `<OPTIONS>`: Zero or more slash-separated parameters:
+  - `ADSPORT=<port>/`: ADS port (typically 851).
+
+  - `TS_MS=<sample_time_ms>/`: PLC sampling period in milliseconds.
+
+  - `T_DLY_MS=<max_delay_ms>/`: Maximum buffering time before transmission (ms).
+
+  - `TIMEBASE=PLC/` or `TIMEBASE=EPICS/`: Select timestamp source.
+
+  - `POLL_RATE=<seconds>/`: Value poll rate in seconds.
+
+- `<PLC_SYMBOL>`: PLC variable name;
+  - Note: A special case for this is `.AMSPORTSTATE.`, that can be used instead
+    of a PLC symbol to read / write the current ADSPORT state.
+- `[? | =]:` End symbol with `?` for read access (input or output with readback)
+  or `=` for write access.
+
+A database with several example records can be found in
+[adsExApp/Db/adsTestAsyn.db](adsExApp/Db/adsTestAsyn.db).
+
+The corresponding startup script with necessary configurations is available in
+[startup/adsOnlyIO.cmd](startup/adsOnlyIO.cmd).
 
 ## License information
 
-twincat-ads is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+twincat-ads is free software: you can redistribute it and/or modify it under the
+terms of the GNU Lesser General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later
+version.
 
-twincat-ads is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+twincat-ads is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
 
-You should have received a copy of the GNU Lesser General Public License along with twincat-ads. If not, see <https://www.gnu.org/licenses/>.
-
+You should have received a copy of the GNU Lesser General Public License along
+with twincat-ads. If not, see <https://www.gnu.org/licenses/>.


### PR DESCRIPTION
Add basic build instructions and information about dependencies and module usage.

I did not understand very well the usage of:

https://github.com/epics-modules/twincat-ads/blob/c55d8a8293546a8cdb669f070ed1c4346491b47b/adsApp/src/adsAsynPortDriverUtils.h#L44

So I did not add a description to it.

I am also not 100% sure what's the application of 

https://github.com/epics-modules/twincat-ads/blob/c55d8a8293546a8cdb669f070ed1c4346491b47b/adsApp/src/adsAsynPortDriverUtils.h#L38

and

https://github.com/epics-modules/twincat-ads/blob/c55d8a8293546a8cdb669f070ed1c4346491b47b/adsApp/src/adsAsynPortDriverUtils.h#L40

How are they different? Why do we need to specify scan rates here at all?

I briefly mention them on the README but I think further clarification is needed.

For me it feels more natural that the PLC should be the owner of scan rate settings - EPICS uses `I/O Intr` or SCAN if needed.