### PR TITLE
make RELEASE_PATHS and RELEASE_LIBS optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ dbd/
 iocBoot/
 lib/
 .vscode/
+*.local

--- a/configure/RELEASE
+++ b/configure/RELEASE
@@ -2,9 +2,9 @@
 # Run "gnumake clean uninstall install" in the application
 # top directory each time this file is changed.
 
-include $(TOP)/configure/RELEASE_PATHS.local
+-include $(TOP)/configure/RELEASE_PATHS.local
 -include $(TOP)/configure/RELEASE_PATHS.local.$(EPICS_HOST_ARCH)
-include $(TOP)/configure/RELEASE_LIBS.local
+-include $(TOP)/configure/RELEASE_LIBS.local
 -include $(TOP)/configure/RELEASE.local
 
 #TEMPLATE_TOP=$(EPICS_BASE)/templates/makeBaseApp/top


### PR DESCRIPTION
Those files were added for a custom local build, but they should not be mandatory. At the moment, `make` fails without them. Make files optional so one can build the app only with RELEASE.local as README instructs. Also added *.local to .gitignore.