### PR TITLE
Add ci scripts and build pipelines

### DIFF
--- a/.github/workflows/ci-scripts-build.yml
+++ b/.github/workflows/ci-scripts-build.yml
@@ -1,0 +1,77 @@
+name: twincat-ads
+
+# Trigger on pushes and PRs to any branch
+on:
+  push:
+    paths-ignore:
+      - 'docs/*'
+      - '**/*.html'
+      - '**/*.md'
+  pull_request:
+
+env:
+  SETUP_PATH: .ci-local:.ci
+  MODULES: "asyn"
+
+jobs:
+  build-base:
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    # Set environment variables from matrix parameters
+    env:
+      CMP: ${{ matrix.cmp }}
+      BCFG: ${{ matrix.configuration }}
+      BASE: ${{ matrix.base }}
+      APT: libtirpc-dev
+    strategy:
+      fail-fast: false
+      matrix:
+        # Job names also name artifacts, character limitations apply
+        include:
+          - os: ubuntu-latest
+            cmp: gcc
+            configuration: default
+            base: "R7.0.9"
+            name: "7.0.9 Ubuntu latest"
+
+          - os: ubuntu-22.04
+            cmp: gcc
+            configuration: default
+            base: "R7.0.9"
+            name: "7.0.9 Ubuntu 22.04"
+
+          - os: ubuntu-latest
+            cmp: gcc
+            configuration: default
+            base: "R3.15.9"
+            name: "3.15.9 Ubuntu latest"
+
+          - os: ubuntu-22.04
+            cmp: gcc
+            configuration: default
+            base: "R3.15.9"
+            name: "3.15.9 Ubuntu 22.04"
+
+          - os: macos-latest
+            cmp: gcc
+            base: "R7.0.9"
+            configuration: default
+            name: "R7.0.9 MacOS latest"
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+
+    - name: Prepare and compile dependencies
+      run: python .ci/cue.py prepare
+
+    - name: Build main module
+      run: python .ci/cue.py build
+
+    - name: Run main module tests
+      run: python .ci/cue.py -T 15M test
+
+    - name: Collect and show test results
+      if: ${{ always() }}
+      run: python .ci/cue.py -T 5M test-results

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ dbd/
 iocBoot/
 lib/
 .vscode/
+*.local

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "BeckhoffADS"]
 	path = BeckhoffADS
 	url = https://github.com/Beckhoff/ADS
+[submodule ".ci"]
+	path = .ci
+	url = https://github.com/epics-base/ci-scripts

--- a/configure/RELEASE
+++ b/configure/RELEASE
@@ -2,9 +2,9 @@
 # Run "gnumake clean uninstall install" in the application
 # top directory each time this file is changed.
 
-include $(TOP)/configure/RELEASE_PATHS.local
+-include $(TOP)/configure/RELEASE_PATHS.local
 -include $(TOP)/configure/RELEASE_PATHS.local.$(EPICS_HOST_ARCH)
-include $(TOP)/configure/RELEASE_LIBS.local
+-include $(TOP)/configure/RELEASE_LIBS.local
 -include $(TOP)/configure/RELEASE.local
 
 #TEMPLATE_TOP=$(EPICS_BASE)/templates/makeBaseApp/top


### PR DESCRIPTION
Must be merged after #38
The added pipeline builds `twincat-ads` for the following OS and EPICS base combinations:

```
          - os: ubuntu-latest
            cmp: gcc
            configuration: default
            base: "R7.0.9"
            name: "7.0.9 Ubuntu latest"

          - os: ubuntu-22.04
            cmp: gcc
            configuration: default
            base: "R7.0.9"
            name: "7.0.9 Ubuntu 22.04"

          - os: ubuntu-latest
            cmp: gcc
            configuration: default
            base: "R3.15.9"
            name: "3.15.9 Ubuntu latest"

          - os: ubuntu-22.04
            cmp: gcc
            configuration: default
            base: "R3.15.9"
            name: "3.15.9 Ubuntu 22.04"

          - os: macos-latest
            cmp: gcc
            base: "R7.0.9"
            configuration: default
            name: "R7.0.9 MacOS latest"
```