### PR TITLE
compile under Beckhoff-ADS 113.0.32-1

### DIFF
--- a/adsApp/src/Makefile
+++ b/adsApp/src/Makefile
@@ -14,7 +14,6 @@ include $(TOP)/configure/CONFIG
 #  ADD MACRO DEFINITIONS AFTER THIS LINE
 #=============================
 
-USR_CXXFLAGS += -std=c++11
 USR_CXXFLAGS += -DCONFIG_DEFAULT_LOGLEVEL=1
 USR_CPPFLAGS += -I ../../../BeckhoffADS/AdsLib/
 USR_CPPFLAGS += -I ../../../BeckhoffADS/AdsLib/bhf/


### PR DESCRIPTION
I updated Beckhoff-ADS to 113.0.32-1 tag. There are several updates since our last version (v22), and I see no real reason for keep using old versions.

We can perform some tests on real hardware and check if everything is in place with the new version. 

Build pipelines succeed, which is already a good sign.

From my looks into the library code I think we're good to go - and we want to get any latest bug fixes from Beckhoff - but I did not go through all changes.