### PR TITLE
adsAsynPortDriver::report(): Fix useless null pointer check

### DIFF
--- a/adsApp/src/adsAsynPortDriver.cpp
+++ b/adsApp/src/adsAsynPortDriver.cpp
@@ -721,7 +721,7 @@ void adsAsynPortDriver::report(FILE *fp, int details) {
             functionName);
 
   if (!fp) {
-    fprintf(fp, "%s:%s: ERROR: File NULL.\n", driverName, functionName);
+    printf("%s:%s: ERROR: File NULL.\n", driverName, functionName);
     return;
   }
 


### PR DESCRIPTION
Since it happend that report() was called with fp == null the code had gotten a null pointer check.
However, the code used a fp == null anyway.
Solutution:
Use a simple printf() to report a fp == null in report()