### PR TITLE
Fix confusing bulk read time printf in adsAsynPortDriver

### DIFF
--- a/adsApp/src/adsAsynPortDriver.cpp
+++ b/adsApp/src/adsAsynPortDriver.cpp
@@ -414,13 +414,11 @@ adsAsynPortDriver::adsAsynPortDriver(const char *portName, const char *ipaddr,
     bulk[i].cnt = 0; // Entry is currently unused!!
   bulkTScnt = 0;
   if (defaultSampleTimeMS_ < 1000) {
-    printf("Default Sample Time of %d ms is too small, defaulting to 1Hz.\n",
-           defaultSampleTimeMS_);
     bulk_delay_us = 1000000; // 1 Hz
   } else {
-    printf("Default bulk read time: %d ms\n", defaultSampleTimeMS_);
     bulk_delay_us = defaultSampleTimeMS_ * 1000;
   }
+  printf("bulk read time: %d ms\n", defaultSampleTimeMS_);
   bulkdatasize = 4 * 1024 * 1024; // This is excessive!
   bulkdata = (uint8_t *)malloc(bulkdatasize);
   bulkOK = 0;


### PR DESCRIPTION
Érico Nogueira Rolim points out that the printout about the bulk read time is confusing.
Simplify the printout: Remove the confusing
"Default Sample Time of %d ms is too small"
and print only the resulting time (which is 1000msec or more)