### PR TITLE
Fix wrong value of reported bulk read time

### DIFF
--- a/adsApp/src/adsAsynPortDriver.cpp
+++ b/adsApp/src/adsAsynPortDriver.cpp
@@ -418,7 +418,7 @@ adsAsynPortDriver::adsAsynPortDriver(const char *portName, const char *ipaddr,
   } else {
     bulk_delay_us = defaultSampleTimeMS_ * 1000;
   }
-  printf("bulk read time: %d ms\n", defaultSampleTimeMS_);
+  printf("bulk read time: %d ms\n", bulk_delay_us / 1000);
   bulkdatasize = 4 * 1024 * 1024; // This is excessive!
   bulkdata = (uint8_t *)malloc(bulkdatasize);
   bulkOK = 0;


### PR DESCRIPTION
We set bulk_delay_us to a default value or based on defaultSampleTimeMS_. Make sure the message printed to the terminal is always correct by printing the value of bulk_delay_us in ms.

Fixes: 9a01fcc (Fix confusing bulk read time printf in adsAsynPortDriver, 2026-05-22)