### PR TITLE
Add asynOctetRead/Write support for ADST_STRING

### DIFF
--- a/adsApp/src/adsAsynPortDriver.cpp
+++ b/adsApp/src/adsAsynPortDriver.cpp
@@ -1922,6 +1922,15 @@ asynStatus adsAsynPortDriver::readOctet(asynUser *pasynUser, char *value,
   const char *functionName = "readOctet";
   asynPrint(pasynUser, ASYN_TRACE_FLOW, "%s:%s:\n", driverName, functionName);
 
+  /* Dispatch to base class for PLC STRING parameters (asynParamOctet). The
+   * base class reads the value from the parameter library, which was populated
+   * by setStringParam() inside fireCallbacks(). */
+  if (pAdsParamArray_[pasynUser->reason] != nullptr &&
+      pAdsParamArray_[pasynUser->reason]->plcDataType == ADST_STRING) {
+    return asynPortDriver::readOctet(pasynUser, value, maxChars, nActual,
+                                     eomReason);
+  }
+
   size_t thisRead = 0;
   int reason = 0;
   asynStatus status = asynSuccess;
@@ -2026,6 +2035,27 @@ asynStatus adsAsynPortDriver::writeOctet(asynUser *pasynUser, const char *value,
   const char *functionName = "writeOctet";
   asynPrint(pasynUser, ASYN_TRACE_FLOW, "%s:%s: %s\n", driverName, functionName,
             value);
+
+  /* Write to PLC for STRING parameters (asynParamOctet). The value is
+   * zero-padded to plcSize to satisfy TwinCAT fixed-length string convention.
+   */
+  if (pAdsParamArray_[pasynUser->reason] != nullptr &&
+      pAdsParamArray_[pasynUser->reason]->plcDataType == ADST_STRING) {
+    adsParamInfo *paramInfo = pAdsParamArray_[pasynUser->reason];
+    size_t inputSize = (size_t)(paramInfo->plcSize - 1);
+    size_t copyLen = inputSize > maxChars ? maxChars : inputSize;
+    char *writeBuf = (char *)calloc(paramInfo->plcSize, 1);
+    if (!writeBuf) {
+      return asynError;
+    }
+    memcpy(writeBuf, value, copyLen);
+    asynStatus stat = adsWriteParam(paramInfo, writeBuf, paramInfo->plcSize);
+    free(writeBuf);
+    if (stat == asynSuccess) {
+      *nActual = copyLen;
+    }
+    return stat;
+  }
 
   size_t thisWrite = 0;
   asynStatus status = asynError;
@@ -4599,6 +4629,10 @@ asynStatus adsAsynPortDriver::adsUpdateParameter(adsParamInfo *paramInfo,
       // handled in fireCallbacks()
       ret = asynSuccess;
       break;
+    case asynParamOctet:
+      // handled in fireCallbacks()
+      ret = asynSuccess;
+      break;
     default:
       asynPrint(pasynUserSelf, ASYN_TRACE_ERROR,
                 "%s:%s: Type combination not supported. PLC type = %s, ASYN "
@@ -4797,6 +4831,18 @@ asynStatus adsAsynPortDriver::fireCallbacks(adsParamInfo *paramInfo) {
                                  paramInfo->lastCallbackSize,
                                  paramInfo->paramIndex, paramInfo->asynAddr);
       break;
+    case asynParamOctet: {
+      char *buf = (char *)paramInfo->arrayDataBuffer;
+      size_t safeSz = paramInfo->lastCallbackSize;
+      if (safeSz > paramInfo->plcSize)
+        safeSz = paramInfo->plcSize;
+      if (safeSz > 0)
+        buf[safeSz - 1] = '\0'; // ensure null termination
+      ret = setStringParam(paramInfo->paramIndex, buf);
+      if (ret == asynSuccess)
+        ret = callParamCallbacks(paramInfo->asynAddr, 0);
+      break;
+    }
     default:
       asynPrint(pasynUserSelf, ASYN_TRACE_ERROR,
                 "%s:%s: Type combination not supported. PLC type = %s, ASYN "

--- a/adsApp/src/adsAsynPortDriverUtils.cpp
+++ b/adsApp/src/adsAsynPortDriverUtils.cpp
@@ -458,8 +458,11 @@ asynParamType dtypStringToAsynType(char *dtype) {
       strcmp("asynFloat64ArrayOut", dtype) == 0) {
     return asynParamFloat64Array;
   }
+  if (strcmp("asynOctetRead", dtype) == 0 ||
+      strcmp("asynOctetWrite", dtype) == 0) {
+    return asynParamOctet;
+  }
   //  asynParamUInt32Digital,
-  //  asynParamOctet,
   //  asynParamGenericPointer
 
   return asynParamNotDefined;

--- a/adsExApp/Db/adsTestAsyn.db
+++ b/adsExApp/Db/adsTestAsyn.db
@@ -371,6 +371,77 @@ record(waveform,"$(P)GetSTest"){
 }
 
 ###############################################################################
+# sTest (native string): stringout/stringin and lso/lsi
+#        The same PLC variable is also accessible via asynInt8ArrayOut/In
+#        (see SetSTestRB/GetSTest above).
+#        Uses DTYP asynOctetWrite/asynOctetRead for direct string access without
+#        client-side formatting.
+#
+#        stringout/stringin: up to 40 characters
+#        lso/lsi:            longer strings; SIZV must be >= plcSize + 1
+#
+#        Three patterns for each:
+#             1. output with readback  (I/O intr)
+#             2. output without readback
+#             3. input  I/O intr
+
+record(stringout,"$(P)SetSTestStringRB"){
+    field(PINI, "1")
+    field(TSE,  "-2")
+    field(DTYP, "asynOctetWrite")
+    field(OUT,  "@asyn($(PORT),0,1)ADSPORT=$(ADSPORT=851)/Main.sTest?")
+    field(SCAN, "Passive")
+
+    info(asyn:READBACK,"1")
+}
+
+record(stringout,"$(P)SetSTestString"){
+    field(PINI, "1")
+    field(TSE,  "-2")
+    field(DTYP, "asynOctetWrite")
+    field(OUT,  "@asyn($(PORT),0,1)ADSPORT=$(ADSPORT=851)/Main.sTest=")
+    field(SCAN, "Passive")
+}
+
+record(stringin,"$(P)GetSTestString"){
+    field(PINI, "1")
+    field(TSE,  "-2")
+    field(DTYP, "asynOctetRead")
+    field(INP,  "@asyn($(PORT),0,1)ADSPORT=$(ADSPORT=851)/Main.sTest?")
+    field(SCAN, "I/O Intr")
+}
+
+# longer strings
+record(lso,"$(P)SetSTestLsoRB"){
+    field(PINI, "1")
+    field(TSE,  "-2")
+    field(DTYP, "asynOctetWrite")
+    field(OUT,  "@asyn($(PORT),0,1)ADSPORT=$(ADSPORT=851)/Main.sTest?")
+    field(SIZV, "100")
+    field(SCAN, "Passive")
+
+    info(asyn:READBACK,"1")
+}
+
+record(lso,"$(P)SetSTestLso"){
+    field(PINI, "1")
+    field(TSE,  "-2")
+    field(DTYP, "asynOctetWrite")
+    field(OUT,  "@asyn($(PORT),0,1)ADSPORT=$(ADSPORT=851)/Main.sTest=")
+    field(SIZV, "100")
+    field(SCAN, "Passive")
+}
+
+record(lsi,"$(P)GetSTestLsi"){
+    field(PINI, "1")
+    field(TSE,  "-2")
+    field(DTYP, "asynOctetRead")
+    field(INP,  "@asyn($(PORT),0,1)ADSPORT=$(ADSPORT=851)/Main.sTest?")
+    field(SIZV, "100")
+    field(SCAN, "I/O Intr")
+}
+
+###############################################################################
 # Int8Array: waveform Output and Input
 #        Three different types:
 #             1. waveform with readback  (I/O intr)


### PR DESCRIPTION
So far, one could interact with strings from PLC only if using waveform records combined with array DTYPs to get the ASCII characters. This made it possible to get human-readable text only if using client-side formatting, such as `caget -S <pvname>` (not available in pvget), or using "Format" field in OPI clients such as Phoebus/PyDM/WEISS.

Fix that by allowing usage of EPICS string records (stringin, stringout, lsi, lso) to read and write ADST_STRING variables directly using DTYP = "asynOctetRead" or "asynOctetWrite". For more details, see [1].

[1] - https://github.com/epics-modules/twincat-ads/issues/28