### PR TITLE
adsAsynPortDriver: handle PLC reconnection properly

### DIFF
--- a/adsApp/src/adsAsynPortDriver.cpp
+++ b/adsApp/src/adsAsynPortDriver.cpp
@@ -15,7 +15,7 @@
    along with twincat-ads. If not, see <https://www.gnu.org/licenses/>.
 
 */
-//#define MCB_DEBUG
+// #define MCB_DEBUG
 /*
  * adsAsynPortDriver.cpp
  *
@@ -508,6 +508,8 @@ adsAsynPortDriver::~adsAsynPortDriver() {
 void adsAsynPortDriver::cyclicThread() {
   const char *functionName = "cyclicThread";
   double sampleTime = 0.5;
+  const double reconnectIntervalSecs = 5.0;
+  epicsTimeStamp lastReconnectTime = {};
   while (1) {
     asynPrint(pasynUserSelf, ASYN_TRACE_FLOW, "%s:%s: Sample time [s]= %lf.\n",
               driverName, functionName, sampleTime);
@@ -549,7 +551,6 @@ void adsAsynPortDriver::cyclicThread() {
           asynPrint(pasynUserSelf, ASYN_TRACE_ERROR,
                     "%s:%s: connection failed for port %s.\n", driverName,
                     functionName, portName);
-          exit(-1);
         }
         if (!port->connectedOld && port->connected) {
           adsReadVersion(port);
@@ -597,16 +598,25 @@ void adsAsynPortDriver::cyclicThread() {
     }
 
     if (!oneAmsConnectionOK && autoConnect_) {
-      if (oneAmsConnectionOKold_) {
-        asynPrint(pasynUserSelf, ASYN_TRACE_ERROR,
-                  "%s:%s: No connection! Try to reconnect...\n", driverName,
-                  functionName);
-      }
       connectedAds_ = 0;
-      if ((notConnectedCounter_ & 2) == 2) {
+      // Retry reconnection every 5 seconds
+      epicsTimeStamp now;
+      epicsTimeGetCurrent(&now);
+      if (epicsTimeDiffInSeconds(&now, &lastReconnectTime) >=
+          reconnectIntervalSecs) {
         asynPrint(pasynUserSelf, ASYN_TRACE_ERROR,
-                  "cyclicThread: forcing disconnect.\n");
+                  "%s:%s: PLC unreachable, attempting reconnect...\n",
+                  driverName, functionName);
         disconnectLock(pasynUserSelf);
+        asynStatus reconnectStatus = connectLock(pasynUserSelf);
+        lastReconnectTime = now;
+        if (reconnectStatus != asynSuccess) {
+          asynPrint(pasynUserSelf, ASYN_TRACE_FLOW,
+                    "%s:%s: Reconnect failed.\n", driverName, functionName);
+        } else {
+          asynPrint(pasynUserSelf, ASYN_TRACE_FLOW, "%s:%s: Reconnected.\n",
+                    driverName, functionName);
+        }
       }
     }
     oneAmsConnectionOKold_ = oneAmsConnectionOK;
@@ -3559,10 +3569,11 @@ asynStatus adsAsynPortDriver::adsGetSymInfoByName(uint16_t amsPort,
         driverName, functionName, varName, adsErrorToString(infoStatus),
         infoStatus);
     if (infoStatus == GLOBALERR_TARGET_PORT) {
-      /* Sigh.  It was up, now it's down.  Let's go home. */
+      /* Port went down. Return error and let the reconnection loop handle it.
+       */
       asynPrint(pasynUserSelf, ASYN_TRACE_ERROR,
-                "%s:%s: Port error, giving up!\n", driverName, functionName);
-      exit(1);
+                "%s:%s: Port error, connection will be retried.\n", driverName,
+                functionName);
     }
     return asynError;
   }


### PR DESCRIPTION
Previously the IOC would exit immediately whenever the PLC went offline, due to three unconditional exit() calls:

1. cyclicThread() called exit(-1) as soon as any AMS port transitioned from connected to disconnected, preventing any recovery.

2. The reconnect block in cyclicThread() called disconnectLock() but never called connect() afterward, so reconnection was impossible even if the exit were removed.

3. adsGetSymInfoByName() called exit(1) when a symbol lookup returned GLOBALERR_TARGET_PORT (port went down during lookup).

Fix:
- Remove exit(-1) from the connection-lost block in cyclicThread(). Invalidation, COMM_ALARM, and refreshNeeded are kept intact so that PVs correctly report invalid status while the PLC is offline.
- Add connect(pasynUserSelf) after disconnectLock() in the reconnect block, and retry every 5 seconds. The IOC should retry indefinitely until the PLC comes back.
- Remove exit(1) from the GLOBALERR_TARGET_PORT handler in adsGetSymInfoByName(); return asynError instead and let the cyclic reconnection loop handle recovery.

Closes [1].

1 - https://github.com/epics-modules/twincat-ads/issues/50