### PR TITLE
replace all manual functionName assignments

### DIFF
--- a/adsApp/src/adsAsynPortDriver.cpp
+++ b/adsApp/src/adsAsynPortDriver.cpp
@@ -69,7 +69,7 @@ static initHookState currentEpicsState = initHookAtIocBuild;
  * changes.
  */
 static void getEpicsState(initHookState state) {
-  const char *functionName = "getEpicsState";
+  const char *functionName = __FUNCTION__;
   static struct timeval start;
   struct timeval now, diff;
 
@@ -131,7 +131,7 @@ static void
 adsSymbolsChangedCallback(const AmsAddr *pAddr,
                           const AdsNotificationHeader *pNotification,
                           uint32_t hUser) {
-  const char *functionName = "adsSymbolsChangedCallback";
+  const char *functionName = __FUNCTION__;
 
   if (!adsAsynPortObj) {
     printf("%s:%s: ERROR: adsAsynPortObj==NULL\n", driverName, functionName);
@@ -157,7 +157,7 @@ adsSymbolsChangedCallback(const AmsAddr *pAddr,
 static void adsDataCallback(const AmsAddr *pAddr,
                             const AdsNotificationHeader *pNotification,
                             uint32_t hUser) {
-  const char *functionName = "adsDataCallback";
+  const char *functionName = __FUNCTION__;
 
   if (!adsAsynPortObj) {
     printf("%s:%s: ERROR: adsAsynPortObj==NULL\n", driverName, functionName);
@@ -296,7 +296,7 @@ adsAsynPortDriver::adsAsynPortDriver(const char *portName, const char *ipaddr,
           priority,      /* Default priority */
           0)             /* Default stack size*/
 {
-  const char *functionName = "adsAsynPortDriver";
+  const char *functionName = __FUNCTION__;
   // Extra Debugging from the beginning: pasynTrace->setTraceMask(pasynUserSelf,
   // 0x11);
   asynPrint(pasynUserSelf, ASYN_TRACE_FLOW, "%s:%s:\n", driverName,
@@ -467,7 +467,7 @@ adsAsynPortDriver::adsAsynPortDriver(const char *portName, const char *ipaddr,
  * Cleanup and deallocation of variables.
  */
 adsAsynPortDriver::~adsAsynPortDriver() {
-  const char *functionName = "~adsAsynPortDriver";
+  const char *functionName = __FUNCTION__;
   asynPrint(pasynUserSelf, ASYN_TRACE_FLOW, "%s:%s:\n", driverName,
             functionName);
 
@@ -506,7 +506,7 @@ adsAsynPortDriver::~adsAsynPortDriver() {
  * At reconnect all symbolic handles and callbacks will be reregistered.
  */
 void adsAsynPortDriver::cyclicThread() {
-  const char *functionName = "cyclicThread";
+  const char *functionName = __FUNCTION__;
   double sampleTime = 0.5;
   while (1) {
     asynPrint(pasynUserSelf, ASYN_TRACE_FLOW, "%s:%s: Sample time [s]= %lf.\n",
@@ -615,7 +615,7 @@ void adsAsynPortDriver::cyclicThread() {
 
 /* TBD - Poll at different rates depending on pollClass! */
 void adsAsynPortDriver::bulkReadThread() {
-  const char *functionName = "bulkReadThread";
+  const char *functionName = __FUNCTION__;
   struct timeval start, now;
   uint32_t bytesRead;
   long status;
@@ -714,7 +714,7 @@ void adsAsynPortDriver::bulkReadThread() {
  * Check ads state of all connected ams ports and reconnects if needed.
  */
 void adsAsynPortDriver::report(FILE *fp, int details) {
-  const char *functionName = "report";
+  const char *functionName = __FUNCTION__;
   asynPrint(pasynUserSelf, ASYN_TRACE_FLOW, "%s:%s:\n", driverName,
             functionName);
 
@@ -846,7 +846,7 @@ asynStatus adsAsynPortDriver::disconnectLock(asynUser *pasynUser) {
  * \return asynSuccess or asynError.
  */
 asynStatus adsAsynPortDriver::disconnect(asynUser *pasynUser) {
-  const char *functionName = "disconnect";
+  const char *functionName = __FUNCTION__;
   asynPrint(pasynUser, ASYN_TRACE_FLOW, "%s:%s:\n", driverName, functionName);
 
   asynStatus disconnectStatus = adsDisconnect();
@@ -881,7 +881,7 @@ asynStatus adsAsynPortDriver::refreshParamsLock(uint16_t amsPort) {
  * \return asynSuccess or asynError.
  */
 asynStatus adsAsynPortDriver::refreshParams(uint16_t amsPort) {
-  const char *functionName = "refreshParams";
+  const char *functionName = __FUNCTION__;
   asynPrint(pasynUserSelf, ASYN_TRACE_FLOW, "%s:%s:\n", driverName,
             functionName);
 
@@ -933,7 +933,7 @@ asynStatus adsAsynPortDriver::invalidateParamsLock(uint16_t amsPort) {
  * \return asynSuccess or asynError.
  */
 asynStatus adsAsynPortDriver::invalidateParams(uint16_t amsPort) {
-  const char *functionName = "invalidateParams";
+  const char *functionName = __FUNCTION__;
   asynPrint(pasynUserSelf, ASYN_TRACE_FLOW, "%s:%s:\n", driverName,
             functionName);
 
@@ -981,7 +981,7 @@ asynStatus adsAsynPortDriver::connectLock(asynUser *pasynUser) {
  * \return asynSuccess or asynError.
  */
 asynStatus adsAsynPortDriver::connect(asynUser *pasynUser) {
-  const char *functionName = "connect";
+  const char *functionName = __FUNCTION__;
   asynPrint(pasynUser, ASYN_TRACE_FLOW, "%s:%s: %s\n", driverName, functionName,
             epicsThreadGetNameSelf());
 
@@ -1007,7 +1007,7 @@ asynStatus adsAsynPortDriver::connect(asynUser *pasynUser) {
  * field of an record.
  */
 asynStatus adsAsynPortDriver::validateDrvInfo(const char *drvInfo) {
-  const char *functionName = "validateDrvInfo";
+  const char *functionName = __FUNCTION__;
   asynPrint(pasynUserSelf, ASYN_TRACE_FLOW, "%s:%s: drvInfo: %s\n", driverName,
             functionName, drvInfo);
 
@@ -1051,7 +1051,7 @@ asynStatus adsAsynPortDriver::drvUserCreate(asynUser *pasynUser,
                                             const char *drvInfo,
                                             const char **pptypeName,
                                             size_t *psize) {
-  const char *functionName = "drvUserCreate";
+  const char *functionName = __FUNCTION__;
   static int vcnt = 0;
 
   asynPrint(pasynUser, ASYN_TRACE_FLOW, "%s:%s: drvInfo: %s\n", driverName,
@@ -1198,7 +1198,7 @@ asynStatus adsAsynPortDriver::drvUserCreate(asynUser *pasynUser,
  */
 asynStatus
 adsAsynPortDriver::updateParamInfoWithPLCInfo(adsParamInfo *paramInfo) {
-  const char *functionName = "updateParamInfoWithPLCInfo";
+  const char *functionName = __FUNCTION__;
   asynPrint(pasynUserSelf, ASYN_TRACE_FLOW, "%s:%s: : %s\n", driverName,
             functionName, paramInfo->drvInfo);
 
@@ -1433,7 +1433,7 @@ int adsAsynPortDriver::adsFindBulkTimeStamp(uint16_t amsPort) {
 asynStatus
 adsAsynPortDriver::getRecordInfoFromDrvInfo(const char *drvInfo,
                                             adsParamInfo *paramInfo) {
-  const char *functionName = "getRecordInfoFromDrvInfo";
+  const char *functionName = __FUNCTION__;
   asynPrint(pasynUserSelf, ASYN_TRACE_FLOW, "%s:%s: drvInfo: %s\n", driverName,
             functionName, drvInfo);
 
@@ -1556,7 +1556,7 @@ adsAsynPortDriver::getRecordInfoFromDrvInfo(const char *drvInfo,
  */
 asynStatus adsAsynPortDriver::parsePlcInfofromDrvInfo(const char *drvInfo,
                                                       adsParamInfo *paramInfo) {
-  const char *functionName = "parsePlcInfofromDrvInfo";
+  const char *functionName = __FUNCTION__;
   asynPrint(pasynUserSelf, ASYN_TRACE_FLOW, "%s:%s: drvInfo: %s\n", driverName,
             functionName, drvInfo);
 
@@ -1808,7 +1808,7 @@ asynStatus adsAsynPortDriver::parsePlcInfofromDrvInfo(const char *drvInfo,
  * \return amsPortInfo object.
  */
 amsPortInfo *adsAsynPortDriver::getAmsPortObject(uint16_t amsPort) {
-  const char *functionName = "getAmsPortObject";
+  const char *functionName = __FUNCTION__;
   asynPrint(pasynUserSelf, ASYN_TRACE_FLOW, "%s:%s: amsPort:%u\n", driverName,
             functionName, amsPort);
 
@@ -1825,7 +1825,7 @@ amsPortInfo *adsAsynPortDriver::getAmsPortObject(uint16_t amsPort) {
  * \return asynSuccess or asynError.
  */
 asynStatus adsAsynPortDriver::addNewAmsPortToList(uint16_t amsPort) {
-  const char *functionName = "addNewAmsPortToList";
+  const char *functionName = __FUNCTION__;
   asynPrint(pasynUserSelf, ASYN_TRACE_FLOW, "%s:%s: amsPort:%u\n", driverName,
             functionName, amsPort);
 
@@ -1879,7 +1879,7 @@ bool adsAsynPortDriver::isCallbackAllowed(adsParamInfo *paramInfo) {
  * \return true if connection ti ams-port is ok otherwise false.
  */
 bool adsAsynPortDriver::isCallbackAllowed(uint16_t amsPort) {
-  const char *functionName = "isCallbackAllowed";
+  const char *functionName = __FUNCTION__;
   asynPrint(pasynUserSelf, ASYN_TRACE_FLOW, "%s:%s: amsPort:%u\n", driverName,
             functionName, amsPort);
 
@@ -1919,7 +1919,7 @@ bool adsAsynPortDriver::isCallbackAllowed(uint16_t amsPort) {
 asynStatus adsAsynPortDriver::readOctet(asynUser *pasynUser, char *value,
                                         size_t maxChars, size_t *nActual,
                                         int *eomReason) {
-  const char *functionName = "readOctet";
+  const char *functionName = __FUNCTION__;
   asynPrint(pasynUser, ASYN_TRACE_FLOW, "%s:%s:\n", driverName, functionName);
 
   /* Dispatch to base class for PLC STRING parameters (asynParamOctet). The
@@ -1983,7 +1983,7 @@ asynStatus adsAsynPortDriver::readOctet(asynUser *pasynUser, char *value,
  * \return 0 for success or error code.
  */
 int adsAsynPortDriver::octetCMDreadIt(char *outbuf, size_t outlen) {
-  const char *functionName = "octetCMDreadIt";
+  const char *functionName = __FUNCTION__;
   asynPrint(pasynUserSelf, ASYN_TRACE_FLOW, "%s:%s: Buffer: %s, size: %d\n",
             driverName, functionName, outbuf, (int)outlen);
 
@@ -2032,7 +2032,7 @@ int adsAsynPortDriver::octetCMDreadIt(char *outbuf, size_t outlen) {
  */
 asynStatus adsAsynPortDriver::writeOctet(asynUser *pasynUser, const char *value,
                                          size_t maxChars, size_t *nActual) {
-  const char *functionName = "writeOctet";
+  const char *functionName = __FUNCTION__;
   asynPrint(pasynUser, ASYN_TRACE_FLOW, "%s:%s: %s\n", driverName, functionName,
             value);
 
@@ -2095,7 +2095,7 @@ asynStatus adsAsynPortDriver::writeOctet(asynUser *pasynUser, const char *value,
  * \return 0 for success or error code.
  */
 int adsAsynPortDriver::octetCMDwriteIt(const char *inbuf, size_t inlen) {
-  const char *functionName = "octetCMDwriteIt";
+  const char *functionName = __FUNCTION__;
   asynPrint(pasynUserSelf, ASYN_TRACE_FLOW,
             "%s:%s: Write command: %s, length: %d\n", driverName, functionName,
             inbuf, (int)inlen);
@@ -2133,7 +2133,7 @@ int adsAsynPortDriver::octetCMDwriteIt(const char *inbuf, size_t inlen) {
 
 int adsAsynPortDriver::octetCmdHandleInputLine(
     const char *input_line, adsOctetOutputBufferType *buffer) {
-  const char *functionName = "octetCmdHandleInputLine";
+  const char *functionName = __FUNCTION__;
   asynPrint(pasynUserSelf, ASYN_TRACE_FLOW, "%s:%s: Input line: %s\n",
             driverName, functionName, input_line);
 
@@ -2173,7 +2173,7 @@ int adsAsynPortDriver::octetCmdHandleInputLine(
  */
 int adsAsynPortDriver::octetMotorHandleOneArg(
     const char *myarg_1, adsOctetOutputBufferType *buffer) {
-  const char *functionName = "octetMotorHandleOneArg";
+  const char *functionName = __FUNCTION__;
   asynPrint(pasynUserSelf, ASYN_TRACE_FLOW, "%s:%s: Command: %s\n", driverName,
             functionName, myarg_1);
 
@@ -2266,7 +2266,7 @@ int adsAsynPortDriver::octetMotorHandleOneArg(
  */
 int adsAsynPortDriver::octetMotorHandleADRCmd(
     const char *arg, uint16_t amsport, adsOctetOutputBufferType *buffer) {
-  const char *functionName = "octetMotorHandleADRCmd";
+  const char *functionName = __FUNCTION__;
   asynPrint(pasynUserSelf, ASYN_TRACE_FLOW, "%s:%s: Command: %s, amsPort: %d\n",
             driverName, functionName, arg, (int)amsport);
 
@@ -2339,7 +2339,7 @@ int adsAsynPortDriver::octetMotorHandleADRCmd(
 int adsAsynPortDriver::octetAdsReadByName(uint16_t amsPort,
                                           const char *variableAddr,
                                           adsOctetOutputBufferType *outBuffer) {
-  const char *functionName = "octetAdsReadByName";
+  const char *functionName = __FUNCTION__;
   asynPrint(pasynUserSelf, ASYN_TRACE_FLOW, "%s:%s: Variable:%s, amsPort %u\n",
             driverName, functionName, variableAddr, amsPort);
 
@@ -2369,7 +2369,7 @@ int adsAsynPortDriver::octetAdsReadByName(uint16_t amsPort,
 int adsAsynPortDriver::octetAdsWriteByName(
     uint16_t amsPort, const char *variableAddr, const char *asciiValueToWrite,
     adsOctetOutputBufferType *outBuffer) {
-  const char *functionName = "octetAdsWriteByName";
+  const char *functionName = __FUNCTION__;
   asynPrint(pasynUserSelf, ASYN_TRACE_FLOW, "%s:%s: Variable: %s, value: %s.\n",
             driverName, functionName, variableAddr, asciiValueToWrite);
 
@@ -2400,7 +2400,7 @@ int adsAsynPortDriver::octetAdsWriteByName(
 int adsAsynPortDriver::octetAdsReadByGroupOffset(
     uint16_t amsPort, adsSymbolEntry *info,
     adsOctetOutputBufferType *outBuffer) {
-  const char *functionName = "octetAdsReadByGroupOffset";
+  const char *functionName = __FUNCTION__;
   asynPrint(pasynUserSelf, ASYN_TRACE_FLOW,
             "%s:%s: amsPort: %d, group: %d, offset: %d, dataType: %s (%d), "
             "dataSize: %d.\n",
@@ -2485,7 +2485,7 @@ int adsAsynPortDriver::octetAdsWriteByGroupOffset(
     uint16_t amsPort, uint32_t group, uint32_t offset, uint16_t dataType,
     uint32_t dataSize, const char *asciiValueToWrite,
     adsOctetOutputBufferType *asciiResponseBuffer) {
-  const char *functionName = "octetAdsWriteByGroupOffset";
+  const char *functionName = __FUNCTION__;
   asynPrint(pasynUserSelf, ASYN_TRACE_FLOW,
             "%s:%s: amsPort: %d, group: %d, offset: %d, dataType: %s (%d), "
             "dataSize: %d.\n",
@@ -2538,7 +2538,7 @@ int adsAsynPortDriver::octetAdsWriteByGroupOffset(
  */
 asynStatus adsAsynPortDriver::writeInt32(asynUser *pasynUser,
                                          epicsInt32 value) {
-  const char *functionName = "writeInt32";
+  const char *functionName = __FUNCTION__;
   asynPrint(pasynUser, ASYN_TRACE_FLOW, "%s:%s:\n", driverName, functionName);
   adsParamInfo *paramInfo;
   int paramIndex = pasynUser->reason;
@@ -2688,7 +2688,7 @@ asynStatus adsAsynPortDriver::writeInt32(asynUser *pasynUser,
  */
 asynStatus adsAsynPortDriver::writeFloat64(asynUser *pasynUser,
                                            epicsFloat64 value) {
-  const char *functionName = "writeFloat64";
+  const char *functionName = __FUNCTION__;
   asynPrint(pasynUser, ASYN_TRACE_FLOW, "%s:%s:\n", driverName, functionName);
 
   adsParamInfo *paramInfo;
@@ -2847,7 +2847,7 @@ asynStatus adsAsynPortDriver::adsGenericArrayRead(asynUser *pasynUser,
                                                   void *epicsDataBuffer,
                                                   size_t nEpicsBufferBytes,
                                                   size_t *nBytesRead) {
-  const char *functionName = "adsGenericArrayRead";
+  const char *functionName = __FUNCTION__;
   asynPrint(pasynUser, ASYN_TRACE_FLOW, "%s:%s:\n", driverName, functionName);
 
   int paramIndex = pasynUser->reason;
@@ -2913,7 +2913,7 @@ asynStatus adsAsynPortDriver::adsGenericArrayWrite(asynUser *pasynUser,
                                                    long allowedType,
                                                    const void *data,
                                                    size_t nEpicsBufferBytes) {
-  const char *functionName = "adsGenericArrayWrite";
+  const char *functionName = __FUNCTION__;
   asynPrint(pasynUser, ASYN_TRACE_FLOW, "%s:%s:\n", driverName, functionName);
 
   int paramIndex = pasynUser->reason;
@@ -2977,7 +2977,7 @@ asynStatus adsAsynPortDriver::adsGenericArrayWrite(asynUser *pasynUser,
 asynStatus adsAsynPortDriver::readInt8Array(asynUser *pasynUser,
                                             epicsInt8 *value, size_t nElements,
                                             size_t *nIn) {
-  const char *functionName = "readInt8Array";
+  const char *functionName = __FUNCTION__;
   asynPrint(pasynUser, ASYN_TRACE_FLOW, "%s:%s:\n", driverName, functionName);
 
   if (!pAdsParamArray_[pasynUser->reason]) {
@@ -3017,7 +3017,7 @@ asynStatus adsAsynPortDriver::readInt8Array(asynUser *pasynUser,
 asynStatus adsAsynPortDriver::writeInt8Array(asynUser *pasynUser,
                                              epicsInt8 *value,
                                              size_t nElements) {
-  const char *functionName = "writeInt8Array";
+  const char *functionName = __FUNCTION__;
   asynPrint(pasynUser, ASYN_TRACE_FLOW, "%s:%s:\n", driverName, functionName);
 
   long allowedType = ADST_INT8;
@@ -3045,7 +3045,7 @@ asynStatus adsAsynPortDriver::writeInt8Array(asynUser *pasynUser,
 asynStatus adsAsynPortDriver::readInt16Array(asynUser *pasynUser,
                                              epicsInt16 *value,
                                              size_t nElements, size_t *nIn) {
-  const char *functionName = "readInt16Array";
+  const char *functionName = __FUNCTION__;
   asynPrint(pasynUser, ASYN_TRACE_FLOW, "%s:%s:\n", driverName, functionName);
 
   long allowedType = ADST_INT16;
@@ -3072,7 +3072,7 @@ asynStatus adsAsynPortDriver::readInt16Array(asynUser *pasynUser,
 asynStatus adsAsynPortDriver::writeInt16Array(asynUser *pasynUser,
                                               epicsInt16 *value,
                                               size_t nElements) {
-  const char *functionName = "writeInt16Array";
+  const char *functionName = __FUNCTION__;
   asynPrint(pasynUser, ASYN_TRACE_FLOW, "%s:%s:\n", driverName, functionName);
 
   long allowedType = ADST_INT16;
@@ -3093,7 +3093,7 @@ asynStatus adsAsynPortDriver::writeInt16Array(asynUser *pasynUser,
 asynStatus adsAsynPortDriver::readInt32Array(asynUser *pasynUser,
                                              epicsInt32 *value,
                                              size_t nElements, size_t *nIn) {
-  const char *functionName = "readInt32Array";
+  const char *functionName = __FUNCTION__;
   asynPrint(pasynUser, ASYN_TRACE_FLOW, "%s:%s:\n", driverName, functionName);
 
   long allowedType = ADST_INT32;
@@ -3120,7 +3120,7 @@ asynStatus adsAsynPortDriver::readInt32Array(asynUser *pasynUser,
 asynStatus adsAsynPortDriver::writeInt32Array(asynUser *pasynUser,
                                               epicsInt32 *value,
                                               size_t nElements) {
-  const char *functionName = "writeInt32Array";
+  const char *functionName = __FUNCTION__;
   asynPrint(pasynUser, ASYN_TRACE_FLOW, "%s:%s:\n", driverName, functionName);
 
   long allowedType = ADST_INT32;
@@ -3141,7 +3141,7 @@ asynStatus adsAsynPortDriver::writeInt32Array(asynUser *pasynUser,
 asynStatus adsAsynPortDriver::readFloat32Array(asynUser *pasynUser,
                                                epicsFloat32 *value,
                                                size_t nElements, size_t *nIn) {
-  const char *functionName = "readFloat32Array";
+  const char *functionName = __FUNCTION__;
   asynPrint(pasynUser, ASYN_TRACE_FLOW, "%s:%s:\n", driverName, functionName);
 
   long allowedType = ADST_REAL32;
@@ -3168,7 +3168,7 @@ asynStatus adsAsynPortDriver::readFloat32Array(asynUser *pasynUser,
 asynStatus adsAsynPortDriver::writeFloat32Array(asynUser *pasynUser,
                                                 epicsFloat32 *value,
                                                 size_t nElements) {
-  const char *functionName = "writeFloat32Array";
+  const char *functionName = __FUNCTION__;
   asynPrint(pasynUser, ASYN_TRACE_FLOW, "%s:%s:\n", driverName, functionName);
 
   long allowedType = ADST_REAL32;
@@ -3188,7 +3188,7 @@ asynStatus adsAsynPortDriver::writeFloat32Array(asynUser *pasynUser,
 asynStatus adsAsynPortDriver::readFloat64Array(asynUser *pasynUser,
                                                epicsFloat64 *value,
                                                size_t nElements, size_t *nIn) {
-  const char *functionName = "readFloat64Array";
+  const char *functionName = __FUNCTION__;
   asynPrint(pasynUser, ASYN_TRACE_FLOW, "%s:%s:\n", driverName, functionName);
 
   long allowedType = ADST_REAL64;
@@ -3215,7 +3215,7 @@ asynStatus adsAsynPortDriver::readFloat64Array(asynUser *pasynUser,
 asynStatus adsAsynPortDriver::writeFloat64Array(asynUser *pasynUser,
                                                 epicsFloat64 *value,
                                                 size_t nElements) {
-  const char *functionName = "writeFloat64Array";
+  const char *functionName = __FUNCTION__;
   asynPrint(pasynUser, ASYN_TRACE_FLOW, "%s:%s:\n", driverName, functionName);
 
   long allowedType = ADST_REAL64;
@@ -3228,7 +3228,7 @@ asynStatus adsAsynPortDriver::writeFloat64Array(asynUser *pasynUser,
  * \return pasynUserSelf
  */
 asynUser *adsAsynPortDriver::getTraceAsynUser() {
-  const char *functionName = "getTraceAsynUser";
+  const char *functionName = __FUNCTION__;
   asynPrint(pasynUserSelf, ASYN_TRACE_FLOW, "%s:%s:\n", driverName,
             functionName);
 
@@ -3255,7 +3255,7 @@ asynStatus adsAsynPortDriver::adsGetSymHandleByName(adsParamInfo *paramInfo) {
  */
 asynStatus adsAsynPortDriver::adsGetSymHandleByName(adsParamInfo *paramInfo,
                                                     bool blockErrorMsg) {
-  const char *functionName = "adsGetSymHandleByName";
+  const char *functionName = __FUNCTION__;
   asynPrint(pasynUserSelf, ASYN_TRACE_FLOW, "%s:%s:\n", driverName,
             functionName);
 
@@ -3293,7 +3293,7 @@ asynStatus adsAsynPortDriver::adsGetSymHandleByName(adsParamInfo *paramInfo,
  * \return asynSuccess or asynError.
  */
 asynStatus adsAsynPortDriver::adsAddSymbolsChangedCallback(amsPortInfo *port) {
-  const char *functionName = "adsAddSymbolsChangedCallback";
+  const char *functionName = __FUNCTION__;
   asynPrint(pasynUserSelf, ASYN_TRACE_FLOW, "%s:%s: Ams-port %u.\n", driverName,
             functionName, port->amsPort);
 
@@ -3336,7 +3336,7 @@ asynStatus adsAsynPortDriver::adsAddSymbolsChangedCallback(amsPortInfo *port) {
  * \return asynSuccess or asynError.
  */
 asynStatus adsAsynPortDriver::adsDelSymbolsChangedCallback(amsPortInfo *port) {
-  const char *functionName = "adsDelSymbolsChangedCallback";
+  const char *functionName = __FUNCTION__;
   asynPrint(pasynUserSelf, ASYN_TRACE_FLOW, "%s:%s:\n", driverName,
             functionName);
 
@@ -3367,7 +3367,7 @@ asynStatus adsAsynPortDriver::adsDelSymbolsChangedCallback(amsPortInfo *port) {
  * \return asynSuccess or asynError.
  */
 asynStatus adsAsynPortDriver::adsAddDataCallback(adsParamInfo *paramInfo) {
-  const char *functionName = "adsAddDataCallback";
+  const char *functionName = __FUNCTION__;
   asynPrint(pasynUserSelf, ASYN_TRACE_FLOW, "%s:%s:\n", driverName,
             functionName);
 
@@ -3474,7 +3474,7 @@ asynStatus adsAsynPortDriver::adsDelDataCallback(adsParamInfo *paramInfo) {
  */
 asynStatus adsAsynPortDriver::adsDelDataCallback(adsParamInfo *paramInfo,
                                                  bool blockErrorMsg) {
-  const char *functionName = "adsDelDataCallback";
+  const char *functionName = __FUNCTION__;
   asynPrint(pasynUserSelf, ASYN_TRACE_FLOW, "%s:%s:\n", driverName,
             functionName);
 
@@ -3529,7 +3529,7 @@ asynStatus adsAsynPortDriver::adsGetSymInfoByName(uint16_t amsPort,
                                                   const char *varName,
                                                   adsSymbolEntry *info,
                                                   long *errorCode) {
-  const char *functionName = "adsGetSymInfoByName";
+  const char *functionName = __FUNCTION__;
   asynPrint(pasynUserSelf, ASYN_TRACE_FLOW,
             "%s:%s: Variable name: %s, amsPort: %d.\n", driverName,
             functionName, varName, (int)amsPort);
@@ -3621,7 +3621,7 @@ asynStatus adsAsynPortDriver::adsGetSymInfoByName(uint16_t amsPort,
  * \return asynSuccess or asynError.
  */
 asynStatus adsAsynPortDriver::adsGetSymInfoByName(adsParamInfo *paramInfo) {
-  const char *functionName = "adsGetSymInfoByName";
+  const char *functionName = __FUNCTION__;
   asynPrint(pasynUserSelf, ASYN_TRACE_FLOW, "%s:%s:\n", driverName,
             functionName);
 
@@ -3649,7 +3649,7 @@ asynStatus adsAsynPortDriver::adsGetSymInfoByName(adsParamInfo *paramInfo) {
  * \return asynSuccess or asynError.
  */
 asynStatus adsAsynPortDriver::adsConnect() {
-  const char *functionName = "adsConnect";
+  const char *functionName = __FUNCTION__;
   asynPrint(pasynUserSelf, ASYN_TRACE_FLOW, "%s:%s:\n", driverName,
             functionName);
 
@@ -3715,7 +3715,7 @@ asynStatus adsAsynPortDriver::adsConnect() {
  * \return asynSuccess or asynError.
  */
 asynStatus adsAsynPortDriver::adsReadVersion(amsPortInfo *port) {
-  const char *functionName = "adsReadVersion";
+  const char *functionName = __FUNCTION__;
   asynPrint(pasynUserSelf, ASYN_TRACE_FLOW, "%s:%s: Ams-port %u\n", driverName,
             functionName, port->amsPort);
 
@@ -3745,7 +3745,7 @@ asynStatus adsAsynPortDriver::adsReadVersion(amsPortInfo *port) {
  * \return asynSuccess or asynError.
  */
 asynStatus adsAsynPortDriver::adsDisconnect() {
-  const char *functionName = "adsDisconnect";
+  const char *functionName = __FUNCTION__;
   asynPrint(pasynUserSelf, ASYN_TRACE_FLOW, "%s:%s: adsPort_=%ld\n", driverName,
             functionName, adsPort_);
 
@@ -3784,7 +3784,7 @@ adsAsynPortDriver::adsReleaseSymbolicHandle(adsParamInfo *paramInfo) {
  */
 asynStatus adsAsynPortDriver::adsReleaseSymbolicHandle(adsParamInfo *paramInfo,
                                                        bool blockErrorMsg) {
-  const char *functionName = "adsReleaseHandle";
+  const char *functionName = __FUNCTION__;
   asynPrint(pasynUserSelf, ASYN_TRACE_FLOW, "%s:%s:\n", driverName,
             functionName);
 
@@ -3822,7 +3822,7 @@ asynStatus adsAsynPortDriver::adsReleaseSymbolicHandle(adsParamInfo *paramInfo,
 asynStatus adsAsynPortDriver::adsWriteParam(adsParamInfo *paramInfo,
                                             const void *binaryBuffer,
                                             uint32_t bytesToWrite) {
-  const char *functionName = "adsWriteParam";
+  const char *functionName = __FUNCTION__;
   asynPrint(pasynUserSelf, ASYN_TRACE_FLOW, "%s:%s:\n", driverName,
             functionName);
 
@@ -3917,7 +3917,7 @@ asynStatus adsAsynPortDriver::adsReadParam(adsParamInfo *paramInfo) {
  */
 asynStatus adsAsynPortDriver::adsReadParam(adsParamInfo *paramInfo, long *error,
                                            int updateAsynPar) {
-  const char *functionName = "adsReadParam";
+  const char *functionName = __FUNCTION__;
   asynPrint(pasynUserSelf, ASYN_TRACE_FLOW, "%s:%s:\n", driverName,
             functionName);
 
@@ -4068,7 +4068,7 @@ asynStatus adsAsynPortDriver::adsReadState(uint16_t *adsState) {
 asynStatus adsAsynPortDriver::adsReadState(uint16_t amsport, uint16_t *adsState,
                                            bool blockErrorMsg, long *error) {
 
-  const char *functionName = "adsReadState";
+  const char *functionName = __FUNCTION__;
   asynPrint(pasynUserSelf, ASYN_TRACE_FLOW, "%s:%s:\n", driverName,
             functionName);
 
@@ -4100,7 +4100,7 @@ asynStatus adsAsynPortDriver::adsReadState(uint16_t amsport, uint16_t *adsState,
  */
 asynStatus adsAsynPortDriver::adsWriteState(uint16_t amsport,
                                             uint16_t adsState) {
-  const char *functionName = "adsWriteState";
+  const char *functionName = __FUNCTION__;
   asynPrint(pasynUserSelf, ASYN_TRACE_FLOW, "%s:%s: adsState = %s (%u)\n",
             driverName, functionName, adsStateToString(adsState), adsState);
 
@@ -4131,7 +4131,7 @@ int adsAsynPortDriver::getParamTableSize() { return paramTableSize_; }
  * \return Parameter info structure.
  */
 adsParamInfo *adsAsynPortDriver::getAdsParamInfo(int index) {
-  const char *functionName = "getAdsParamInfo";
+  const char *functionName = __FUNCTION__;
   asynPrint(pasynUserSelf, ASYN_TRACE_FLOW,
             "%s:%s: Get paramInfo for index: %d\n", driverName, functionName,
             index);
@@ -4158,7 +4158,7 @@ int adsAsynPortDriver::getAdsParamCount() { return adsParamArrayCount_; }
  * Refreshes and sets timestamp depending on time source (PLC or EPICS).
  */
 asynStatus adsAsynPortDriver::refreshParamTime(adsParamInfo *paramInfo) {
-  const char *functionName = "refreshParamTime";
+  const char *functionName = __FUNCTION__;
   asynPrint(pasynUserSelf, ASYN_TRACE_FLOW, "%s:%s: plcTime %" PRIuMAX ".\n",
             driverName, functionName, (uintmax_t)paramInfo->plcTimeStampRaw);
 
@@ -4261,7 +4261,7 @@ asynStatus adsAsynPortDriver::adsUpdateParameter(adsParamInfo *paramInfo,
 asynStatus adsAsynPortDriver::adsUpdateParameter(adsParamInfo *paramInfo,
                                                  const void *data,
                                                  size_t dataSize) {
-  const char *functionName = "adsUpdateParameter";
+  const char *functionName = __FUNCTION__;
   asynPrint(pasynUserSelf, ASYN_TRACE_FLOW, "%s:%s:\n", driverName,
             functionName);
 
@@ -4675,7 +4675,7 @@ asynStatus adsAsynPortDriver::adsUpdateParameter(adsParamInfo *paramInfo,
  * \return asynSuccess or asynError.
  */
 asynStatus adsAsynPortDriver::fireAllCallbacksLock() {
-  const char *functionName = "fireAllCallbacksLock";
+  const char *functionName = __FUNCTION__;
   asynPrint(pasynUserSelf, ASYN_TRACE_FLOW, "%s:%s:\n", driverName,
             functionName);
 
@@ -4696,7 +4696,7 @@ asynStatus adsAsynPortDriver::fireAllCallbacksLock() {
  * \return asynSuccess or asynError.
  */
 asynStatus adsAsynPortDriver::fireCallbacks(adsParamInfo *paramInfo) {
-  const char *functionName = "fireCallbacks";
+  const char *functionName = __FUNCTION__;
   asynPrint(pasynUserSelf, ASYN_TRACE_FLOW, "%s:%s:\n", driverName,
             functionName);
 
@@ -4877,7 +4877,7 @@ asynStatus adsAsynPortDriver::fireCallbacks(adsParamInfo *paramInfo) {
  */
 asynStatus adsAsynPortDriver::setAlarmParam(adsParamInfo *paramInfo, int alarm,
                                             int severity) {
-  const char *functionName = "setAlarmParam";
+  const char *functionName = __FUNCTION__;
   asynPrint(pasynUserSelf, ASYN_TRACE_FLOW, "%s:%s:\n", driverName,
             functionName);
 
@@ -5017,7 +5017,7 @@ asynStatus adsAsynPortDriver::setAlarmPortLock(uint16_t amsPort, int alarm,
  */
 asynStatus adsAsynPortDriver::setAlarmPort(uint16_t amsPort, int alarm,
                                            int severity) {
-  const char *functionName = "setAlarmPort";
+  const char *functionName = __FUNCTION__;
   asynPrint(pasynUserSelf, ASYN_TRACE_FLOW, "%s:%s:\n", driverName,
             functionName);
 
@@ -5049,7 +5049,7 @@ void adsAsynPortDriver::adsUnlock() { adsMutex.unlock(); }
  * \return asynSuccess or asynError.
  */
 asynStatus adsAsynPortDriver::adsDelRoute(int force) {
-  const char *functionName = "adsDelRoute";
+  const char *functionName = __FUNCTION__;
   asynPrint(pasynUserSelf, ASYN_TRACE_FLOW, "%s:%s: force = %s\n", driverName,
             functionName, force ? "true" : "false");
   if (routeAdded_ || force) {
@@ -5081,7 +5081,7 @@ asynStatus adsAsynPortDriver::adsDelRouteLock(int force) {
  * Thread safe.
  */
 asynStatus adsAsynPortDriver::adsAddRouteLock() {
-  const char *functionName = "adsAddRouteLock";
+  const char *functionName = __FUNCTION__;
   asynPrint(pasynUserSelf, ASYN_TRACE_FLOW, "%s:%s:\n", driverName,
             functionName);
 
@@ -5294,7 +5294,7 @@ static const iocshFuncDef adsSetLocalAddressFuncDef = {"adsSetLocalAddress", 1,
                                                        adsSetLocalAddressArgs};
 
 static void adsSetLocalAddressCallFunc(const iocshArgBuf *args) {
-  const char *functionName = "adsSetLocalAddress";
+  const char *functionName = __FUNCTION__;
   if (!args[0].sval || strlen(args[0].sval) < 11) {
     printf("%s:%s: local_ams_id parameter required (of the form A.B.C.D.E.F)\n",
            driverName, functionName);


### PR DESCRIPTION
use cpp's builtin `__FUNCTION__ `instead - avoid typos and stale names if functions are renamed.