### PR TITLE
adsAsynPortDriver.cpp: Improve logging for GLOBALERR_TARGET_PORT

### DIFF
--- a/adsApp/src/adsAsynPortDriver.cpp
+++ b/adsApp/src/adsAsynPortDriver.cpp
@@ -442,9 +442,14 @@ adsAsynPortDriver::adsAsynPortDriver(const char *portName, const char *ipaddr,
     long error = 0;
     uint16_t adsState = 0;
     if (adsReadStateLock(amsport, &adsState, true, &error) != asynSuccess) {
-      asynPrint(pasynUserSelf, ASYN_TRACE_ERROR,
-                "%s:%s: adsReadStateLock failed for port '%s' error=0x%lx\n",
-                driverName, functionName, portName, error);
+      asynPrint(
+          pasynUserSelf, ASYN_TRACE_ERROR,
+          "%s:%s: adsReadStateLock failed for port '%s' error='%s' (0x%lx)\n",
+          driverName, functionName, portName,
+          (error == GLOBALERR_TARGET_PORT)
+              ? "Target port not found, PLC program possibly not started"
+              : adsErrorToString(error),
+          error);
       disconnect(pasynUserSelf);
       epicsThreadSleep(5.0);
       continue;
@@ -5098,7 +5103,11 @@ asynStatus adsAsynPortDriver::adsAddRouteLock() {
   if (addRouteStatus) {
     asynPrint(pasynUserSelf, ASYN_TRACE_ERROR,
               "%s:%s: Adding ADS route failed with: %s (0x%lx).\n", driverName,
-              functionName, adsErrorToString(addRouteStatus), addRouteStatus);
+              functionName,
+              (addRouteStatus == GLOBALERR_TARGET_PORT)
+                  ? "Target port not found, ADS server possibly not started"
+                  : adsErrorToString(addRouteStatus),
+              addRouteStatus);
     return asynError;
   }
   routeAdded_ = 1;


### PR DESCRIPTION
When connecting to a PLC system, 2 things may go wrong: a) The network connection is not possible
b) A network connection is possible, but the PLC project, e.g. on port 851,
   is not started.

Improve the logged text, adding something like
"possibly ADS server not started"
or
"possibly PLC program not started"